### PR TITLE
Parameter Customization

### DIFF
--- a/Networking/Model/NetworkingConfiguration.swift
+++ b/Networking/Model/NetworkingConfiguration.swift
@@ -23,40 +23,36 @@ private enum CommunicationProtocol: String {
     It's the only place where these necessary parameters are configured.
  */
 public struct NetworkingConfiguration {
-    /**
-     - Parameters
-     - useSecureConnection: a boolean representing whether the requests
-     will be made using a secure protocol. By default it's enabled.
-     Take into account in case this is disabled, the appropriate
-     exclusions must be added to plist file.
-     - domainURL: the base url the requests will be performed against.
-     - port: the port the requests will be performed against. By default
-     there is no specific port.
-     - subdomainURL: the subdomain url to be appended to domainURL to build
-     the final url (it can be used to specify API versioning). By default it's empty.
-     This url, as a path of the domainURL must start with "/".
-     - usePinningCertificate: a boolean representing if SSL Pinning will be
-     enabled for the performed requests. By default it's disabled. Take into
-     account in case this is enabled, the proper certificate must be included
-     into the application bundle resources.
-     - timeout: the timeout of the requests in seconds. It defaults to 75 seconds.
-     - secondsBetweenPolls: for polling requests, seconds between one polling and the next. It defaults to 1 second.
-     - maximumPollingRetries: Maximum retries until a polling request gives timeout. If it's not set then it will use timeout/secondsBetweenPolls
-     */
-    
+    /// A boolean representing whether the requests will be made using a secure protocol. By default it's enabled.
+    /// Take into account in case this is disabled, the appropriate exclusions must be added to plist file.
     public var useSecureConnection: Bool = true
+    
+    /// The base url the requests will be performed against.
     public var domainURL: String = ""
+    
+    /// The port the requests will be performed against. By default there is no specific port.
     public var port: Int? = .none
+    
+    /// The subdomain url to be appended to domainURL to build the final url (it can be used to specify API versioning). By default it's empty.
+    /// This url, as a path of the domainURL must start with "/".
     public var subdomainURL: String? = .none
+    
+    /// A boolean representing if SSL Pinning will be enabled for the performed requests. By default it's disabled.
+    /// Take into account in case this is enabled, the proper certificate must be included into the application bundle resources.
     public var usePinningCertificate: Bool = false
+    
+    /// The timeout of the requests in seconds. It defaults to 75 seconds.
     public var timeout: Double = 75.0
+    
+    /// For polling requests, seconds between one polling and the next. It defaults to 1 second.
     public var secondsBetweenPolls: Double = 1.0
+    
+    /// Maximum retries until a polling request gives timeout. If it's not set then it will use timeout/secondsBetweenPolls
     public var maximumPollingRetries: Int? = .none
     
     /**
          Initializes the networking configuration with default values.
      */
-    
     public init() {}
 
 }

--- a/Networking/Model/NetworkingConfiguration.swift
+++ b/Networking/Model/NetworkingConfiguration.swift
@@ -24,12 +24,12 @@ private enum CommunicationProtocol: String {
  */
 public struct NetworkingConfiguration {
     
-    fileprivate let _useSecureConnection: Bool
-    fileprivate let _domainURL: String
-    fileprivate let _port: Int?
-    fileprivate let _subdomainURL: String?
-    fileprivate let _timeout: Double
-    fileprivate let _usePinningCertificate: Bool
+    public var useSecureConnection: Bool = true
+    public var domainURL: String = ""
+    public var port: Int? = .none
+    public var subdomainURL: String? = .none
+    public var timeout: Double = 75.0
+    public var usePinningCertificate: Bool = false
     
     /**
         Initializes the networking configuration.
@@ -50,20 +50,9 @@ public struct NetworkingConfiguration {
             account in case this is enabled, the proper certificate must be included
             into the application bundle resources.
     */
-    public init(useSecureConnection: Bool = true,
-                domainURL: String,
-                port: Int? = .none,
-                subdomainURL: String? = .none,
-                timeout: Double = 75.0,
-                usePinningCertificate: Bool = false) {
-        _useSecureConnection = useSecureConnection
-        _domainURL = domainURL
-        _port = port
-        _subdomainURL = subdomainURL
-        _timeout = timeout
-        _usePinningCertificate = usePinningCertificate
-    }
     
+    public init() {}
+
 }
 
 internal extension NetworkingConfiguration {
@@ -71,9 +60,9 @@ internal extension NetworkingConfiguration {
     var baseURL: URL {
         var components = URLComponents()
         components.scheme = communicationProtocol
-        components.host = _domainURL
-        components.port = _port
-        if let subdomainURL = _subdomainURL {
+        components.host = domainURL
+        components.port = port
+        if let subdomainURL = subdomainURL {
             components.path = subdomainURL
         }
         if let url = components.url {
@@ -82,24 +71,12 @@ internal extension NetworkingConfiguration {
         fatalError("Invalid URL parameters in \(String(describing: NetworkingConfiguration.self))")
     }
     
-    var usePinningCertificate: Bool {
-        return _usePinningCertificate
-    }
-    
-    var timeout: Double {
-        return _timeout
-    }
-    
-    var domainURL: String {
-        return _domainURL
-    }
-    
 }
 
 fileprivate extension NetworkingConfiguration {
     
     var communicationProtocol: String {
-        return _useSecureConnection ? CommunicationProtocol.https.rawValue : CommunicationProtocol.http.rawValue
+        return useSecureConnection ? CommunicationProtocol.https.rawValue : CommunicationProtocol.http.rawValue
     }
     
 }

--- a/Networking/Model/NetworkingConfiguration.swift
+++ b/Networking/Model/NetworkingConfiguration.swift
@@ -30,6 +30,8 @@ public struct NetworkingConfiguration {
     public var subdomainURL: String? = .none
     public var timeout: Double = 75.0
     public var usePinningCertificate: Bool = false
+    public var pollTime: Double = 1.0
+    public var maximumPollingRetries: Int = 10
     
     /**
         Initializes the networking configuration.

--- a/Networking/Model/NetworkingConfiguration.swift
+++ b/Networking/Model/NetworkingConfiguration.swift
@@ -28,7 +28,7 @@ public struct NetworkingConfiguration {
     fileprivate let _domainURL: String
     fileprivate let _port: Int?
     fileprivate let _subdomainURL: String?
-    
+    fileprivate let _timeout: Double
     fileprivate let _usePinningCertificate: Bool
     
     /**
@@ -54,11 +54,13 @@ public struct NetworkingConfiguration {
                 domainURL: String,
                 port: Int? = .none,
                 subdomainURL: String? = .none,
+                timeout: Double = 75.0,
                 usePinningCertificate: Bool = false) {
         _useSecureConnection = useSecureConnection
         _domainURL = domainURL
         _port = port
         _subdomainURL = subdomainURL
+        _timeout = timeout
         _usePinningCertificate = usePinningCertificate
     }
     
@@ -82,6 +84,10 @@ internal extension NetworkingConfiguration {
     
     var usePinningCertificate: Bool {
         return _usePinningCertificate
+    }
+    
+    var timeout: Double {
+        return _timeout
     }
     
     var domainURL: String {

--- a/Networking/Model/NetworkingConfiguration.swift
+++ b/Networking/Model/NetworkingConfiguration.swift
@@ -23,35 +23,39 @@ private enum CommunicationProtocol: String {
     It's the only place where these necessary parameters are configured.
  */
 public struct NetworkingConfiguration {
+    /**
+     - Parameters
+     - useSecureConnection: a boolean representing whether the requests
+     will be made using a secure protocol. By default it's enabled.
+     Take into account in case this is disabled, the appropriate
+     exclusions must be added to plist file.
+     - domainURL: the base url the requests will be performed against.
+     - port: the port the requests will be performed against. By default
+     there is no specific port.
+     - subdomainURL: the subdomain url to be appended to domainURL to build
+     the final url (it can be used to specify API versioning). By default it's empty.
+     This url, as a path of the domainURL must start with "/".
+     - usePinningCertificate: a boolean representing if SSL Pinning will be
+     enabled for the performed requests. By default it's disabled. Take into
+     account in case this is enabled, the proper certificate must be included
+     into the application bundle resources.
+     - timeout: the timeout of the requests in seconds. It defaults to 75 seconds.
+     - secondsBetweenPolls: for polling requests, seconds between one polling and the next. It defaults to 1 second.
+     - maximumPollingRetries: Maximum retries until a polling request gives timeout. If it's not set then it will use timeout/secondsBetweenPolls
+     */
     
     public var useSecureConnection: Bool = true
     public var domainURL: String = ""
     public var port: Int? = .none
     public var subdomainURL: String? = .none
-    public var timeout: Double = 75.0
     public var usePinningCertificate: Bool = false
-    public var pollTime: Double = 1.0
-    public var maximumPollingRetries: Int = 10
+    public var timeout: Double = 75.0
+    public var secondsBetweenPolls: Double = 1.0
+    public var maximumPollingRetries: Int? = .none
     
     /**
-        Initializes the networking configuration.
-     
-        - Parameters
-            - useSecureConnection: a boolean representing whether the requests
-            will be made using a secure protocol. By default it's enabled.
-            Take into account in case this is disabled, the appropriate
-            exclusions must be added to plist file.
-            - domainURL: the base url the requests will be performed against.
-            - port: the port the requests will be performed against. By default 
-            there is no specific port.
-            - subdomainURL: the subdomain url to be appended to domainURL to build
-            the final url (it can be used to specify API versioning). By default it's empty. 
-            This url, as a path of the domainURL must start with "/".
-            - usePinningCertificate: a boolean representing if SSL Pinning will be 
-            enabled for the performed requests. By default it's disabled. Take into 
-            account in case this is enabled, the proper certificate must be included
-            into the application bundle resources.
-    */
+         Initializes the networking configuration with default values.
+     */
     
     public init() {}
 
@@ -71,6 +75,13 @@ internal extension NetworkingConfiguration {
             return url
         }
         fatalError("Invalid URL parameters in \(String(describing: NetworkingConfiguration.self))")
+    }
+    
+    /**
+         Returns a default number of times that a polling request will try. In seconds it will match the timeout property.
+     */
+    var defaultPollingRetries: Int {
+        return lround(timeout/secondsBetweenPolls)
     }
     
 }

--- a/Networking/Repository/NetworkingSessionManager.swift
+++ b/Networking/Repository/NetworkingSessionManager.swift
@@ -20,7 +20,7 @@ internal final class NetworkingSessionManager: Alamofire.SessionManager {
         if networkingConfiguration.usePinningCertificate {
             trustPolicyManager = serverTrustPolicyManager(domainURL: networkingConfiguration.domainURL)
         }
-        super.init(configuration: defaultSessionConfiguration, serverTrustPolicyManager: trustPolicyManager)
+        super.init(configuration: defaultSessionConfiguration(networkingConfiguration), serverTrustPolicyManager: trustPolicyManager)
     }
     
 }
@@ -28,9 +28,11 @@ internal final class NetworkingSessionManager: Alamofire.SessionManager {
 /**
     Default session configuration which does not accept cookies by default.
  */
-private var defaultSessionConfiguration: URLSessionConfiguration {
+private func defaultSessionConfiguration(_ networkingConfiguration: NetworkingConfiguration) -> URLSessionConfiguration {
     let configuration = URLSessionConfiguration.default
     configuration.httpCookieStorage?.cookieAcceptPolicy = .never
+    configuration.timeoutIntervalForRequest = networkingConfiguration.timeout
+    configuration.timeoutIntervalForResource = networkingConfiguration.timeout
     return configuration
 }
 

--- a/Networking/Repository/NetworkingSessionManager.swift
+++ b/Networking/Repository/NetworkingSessionManager.swift
@@ -26,7 +26,8 @@ internal final class NetworkingSessionManager: Alamofire.SessionManager {
 }
 
 /**
-    Default session configuration which does not accept cookies by default.
+    Default session configuration which does not accept cookies by default and sets
+    the timeouts to the values set in the networkingConfiguration provided.
  */
 private func defaultSessionConfiguration(_ networkingConfiguration: NetworkingConfiguration) -> URLSessionConfiguration {
     let configuration = URLSessionConfiguration.default

--- a/NetworkingDemo/NetworkingDemoLauncher.swift
+++ b/NetworkingDemo/NetworkingDemoLauncher.swift
@@ -83,11 +83,12 @@ fileprivate extension NetworkingDemoLauncher {
     static let sessionToken = ""
     
     var networkingConfiguration: NetworkingConfiguration {
-        return NetworkingConfiguration(
-            useSecureConnection: true,
-            domainURL: "wbooks-api-stage.herokuapp.com",
-            subdomainURL: "/api/v1",
-            usePinningCertificate: false)
+        var config = NetworkingConfiguration()
+        config.useSecureConnection = true
+        config.domainURL = "wbooks-api-stage.herokuapp.com"
+        config.subdomainURL = "/api/v1"
+        config.usePinningCertificate = false
+        return config
     }
     
 }

--- a/NetworkingTests/Tests/EntityRepositorySpec.swift
+++ b/NetworkingTests/Tests/EntityRepositorySpec.swift
@@ -21,11 +21,13 @@ internal class EntityRepositorySpec: QuickSpec {
             sessionManager = SessionManagerMock()
             sessionManager.login(user: UserMock())
             
-            let networkingConfiguration = NetworkingConfiguration(useSecureConnection: true,
-                                                                  domainURL: "localhost",
-                                                                  port: 8080,
-                                                                  subdomainURL: "/local-path-1.0",
-                                                                  usePinningCertificate: false)
+            var networkingConfiguration = NetworkingConfiguration()
+            
+            networkingConfiguration.useSecureConnection = true
+            networkingConfiguration.domainURL = "localhost"
+            networkingConfiguration.port = 8080
+            networkingConfiguration.subdomainURL = "/local-path-1.0"
+            networkingConfiguration.usePinningCertificate = false
             
             repository = EntityRepository(networkingConfiguration: networkingConfiguration,
                                           requestExecutor: LocalRequestExecutor(),

--- a/NetworkingTests/Tests/LoginRepositorySpec.swift
+++ b/NetworkingTests/Tests/LoginRepositorySpec.swift
@@ -16,12 +16,14 @@ internal class LoginRepositorySpec: QuickSpec {
         
         var repository: LoginRepositoryType!
         
-        beforeEach() {
-            let networkingConfiguration = NetworkingConfiguration(useSecureConnection: true,
-                                                                  domainURL: "localhost",
-                                                                  port: 8080,
-                                                                  subdomainURL: "/local-path-1.0",
-                                                                  usePinningCertificate: false)
+        beforeEach() {            
+            var networkingConfiguration = NetworkingConfiguration()
+            
+            networkingConfiguration.useSecureConnection = true
+            networkingConfiguration.domainURL = "localhost"
+            networkingConfiguration.port = 8080
+            networkingConfiguration.subdomainURL = "/local-path-1.0"
+            networkingConfiguration.usePinningCertificate = false
             
             repository = LoginRepository(networkingConfiguration: networkingConfiguration,
                                          requestExecutor: LocalRequestExecutor(),

--- a/NetworkingTests/Tests/MalformedEntityRepositorySpec.swift
+++ b/NetworkingTests/Tests/MalformedEntityRepositorySpec.swift
@@ -21,11 +21,13 @@ internal class MalformedEntityRepositorySpec: QuickSpec {
             sessionManager = SessionManagerMock()
             sessionManager.login(user: UserMock())
             
-            let networkingConfiguration = NetworkingConfiguration(useSecureConnection: true,
-                                                                  domainURL: "localhost",
-                                                                  port: 8080,
-                                                                  subdomainURL: "/local-path-1.0",
-                                                                  usePinningCertificate: false)
+            var networkingConfiguration = NetworkingConfiguration()
+            
+            networkingConfiguration.useSecureConnection = true
+            networkingConfiguration.domainURL = "localhost"
+            networkingConfiguration.port = 8080
+            networkingConfiguration.subdomainURL = "/local-path-1.0"
+            networkingConfiguration.usePinningCertificate = false
             
             repository = MalformedEntityRepository(networkingConfiguration: networkingConfiguration,
                                                    requestExecutor: LocalRequestExecutor(),

--- a/NetworkingTests/Tests/NetworkingConfigurationSpec.swift
+++ b/NetworkingTests/Tests/NetworkingConfigurationSpec.swift
@@ -21,7 +21,9 @@ internal class NetworkingConfigurationSpec: QuickSpec {
             context("when using http protocol") {
                 
                 beforeEach {
-                    configuration = NetworkingConfiguration(useSecureConnection: false, domainURL: "www.wolox.com.ar")
+                    configuration = NetworkingConfiguration()
+                    configuration.useSecureConnection = false
+                    configuration.domainURL = "www.wolox.com.ar"
                 }
                 
                 it("returns a base url using http protocol") {
@@ -34,7 +36,9 @@ internal class NetworkingConfigurationSpec: QuickSpec {
             context("when using https protocol") {
                 
                 beforeEach {
-                    configuration = NetworkingConfiguration(useSecureConnection: true, domainURL: "www.wolox.com.ar")
+                    configuration = NetworkingConfiguration()
+                    configuration.useSecureConnection = true
+                    configuration.domainURL = "www.wolox.com.ar"
                 }
                 
                 it("returns a base url using https protocol") {
@@ -50,10 +54,10 @@ internal class NetworkingConfigurationSpec: QuickSpec {
             context("when there is port and subdomain") {
                 
                 beforeEach {
-                    configuration = NetworkingConfiguration(
-                        domainURL: "www.wolox.com.ar",
-                        port: 8080,
-                        subdomainURL: "/api/v1")
+                    configuration = NetworkingConfiguration()
+                    configuration.port = 8080
+                    configuration.domainURL = "www.wolox.com.ar"
+                    configuration.subdomainURL = "/api/v1"
                 }
                 
                 it("returns a base url with port and subdomain") {
@@ -65,7 +69,9 @@ internal class NetworkingConfigurationSpec: QuickSpec {
             context("when there is port") {
                 
                 beforeEach {
-                    configuration = NetworkingConfiguration(domainURL: "www.wolox.com.ar", port: 8080)
+                    configuration = NetworkingConfiguration()
+                    configuration.port = 8080
+                    configuration.domainURL = "www.wolox.com.ar"
                 }
                 
                 it("returns a base url with port") {
@@ -77,7 +83,9 @@ internal class NetworkingConfigurationSpec: QuickSpec {
             context("when there is subdomain") {
                 
                 beforeEach {
-                    configuration = NetworkingConfiguration(domainURL: "www.wolox.com.ar", subdomainURL: "/api")
+                    configuration = NetworkingConfiguration()
+                    configuration.domainURL = "www.wolox.com.ar"
+                    configuration.subdomainURL = "/api"
                 }
                 
                 it("returns a base url with subdomain") {


### PR DESCRIPTION
## Summary ##

Made `NetworkingConfiguration` a public struct so it's properties can be set one at a time and have defaults in the other ones.
Added to configuration the property `timeout`, with a deault set to 75 seconds.
Added to configuration the properties `pollTime` and `maximumPollingRetries` with defaults to 1.0 and 10. If the polling requests exceeds the maximum retries without a response it gives a timeout error.
