### PR TITLE
Array encoding

### DIFF
--- a/Networking/Repository/AbstractRepository.swift
+++ b/Networking/Repository/AbstractRepository.swift
@@ -36,23 +36,43 @@ open class AbstractRepository {
 
 extension AbstractRepository: RepositoryType {
     private static let RetryStatusCode = 202
+    internal static let ArrayEncodingParametersKey = "EncodedArray"
     
-    public func performRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]? = .none, headers: [String: String]? = .none,
+    public func performRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]? = .none,
+                                  headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none,
                                   decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
-        return perform(method: method, path: path, parameters: parameters, headers: headers)
+        return perform(method: method, path: path, parameters: parameters, headers: headers, encodeAs: encodeAs)
             .flatMap(.concat) { _, _, data in
                 self.deserializeData(data: data, decoder: decoder)
             }
     }
     
-    public func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]? = .none, headers: [String: String]? = .none,
+    public func performRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
+                                  headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none,
+                                  decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
+        return performRequest(method: method, path: path, parameters: parameters.asParameters(), headers: headers, encodeAs: ArrayEncoding(), decoder: decoder)
+    }
+    
+    public func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]? = .none,
+                                         headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none,
                                          decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
-        return tryPollingRequest(method: method, path: path, tryNumber: 0, decoder: decoder)
+        return tryPollingRequest(method: method, path: path, tryNumber: 0, parameters: parameters, headers: headers, encodeAs: encodeAs, decoder: decoder)
+    }
+    
+    public func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
+                                         headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none,
+                                         decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
+        return performPollingRequest(method: method, path: path, parameters: parameters.asParameters(), headers: headers, encodeAs: ArrayEncoding(), decoder: decoder)
     }
     
     public func performRequest(method: NetworkingMethod, path: String, parameters: [String: Any]? = .none,
-                               headers: [String: String]? = .none) -> SignalProducer<RawDataResponse, RepositoryError> {
-        return perform(method: method, path: path, parameters: parameters, headers: headers)
+                               headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none) -> SignalProducer<RawDataResponse, RepositoryError> {
+        return perform(method: method, path: path, parameters: parameters, headers: headers, encodeAs: encodeAs)
+    }
+    
+    public func performRequest(method: NetworkingMethod, path: String, parameters: [Any],
+                               headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none) -> SignalProducer<RawDataResponse, RepositoryError> {
+        return performRequest(method: method, path: path, parameters: parameters.asParameters(), headers: headers, encodeAs: ArrayEncoding())
     }
     
 }
@@ -88,8 +108,8 @@ private extension AbstractRepository {
     }
     
     func tryPollingRequest<T>(method: NetworkingMethod, path: String, tryNumber: Int = 0, parameters: [String: Any]? = .none,
-                              headers: [String: String]? = .none, decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
-        return perform(method: method, path: path, parameters: parameters, headers: headers)
+                              headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none, decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
+        return perform(method: method, path: path, parameters: parameters, headers: headers, encodeAs: encodeAs)
             .flatMap(.concat) { _, response, data -> SignalProducer<T, RepositoryError> in
                 if response.statusCode != AbstractRepository.RetryStatusCode {
                     return self.deserializeData(data: data, decoder: decoder)
@@ -101,19 +121,19 @@ private extension AbstractRepository {
                 
                 let newTryNumber = tryNumber + 1
                 return self.tryPollingRequest(method: method, path: path, tryNumber: newTryNumber, parameters: parameters,
-                                              headers: headers, decoder: decoder)
+                                              headers: headers, encodeAs: encodeAs, decoder: decoder)
                     .start(on: DelayedScheduler(delay: self._configuration.secondsBetweenPolls))
         }
     }
     
     func perform(method: NetworkingMethod, path: String, parameters: [String: Any]? = .none,
-                 headers: [String: String]? = .none, encoding: Encoding? = .none) -> SignalProducer<RawDataResponse, RepositoryError> {
+                 headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none) -> SignalProducer<RawDataResponse, RepositoryError> {
         
         guard let url = buildURL(path: path) else { return SignalProducer(error: .invalidURL) }
         
         let newHeaders = (headers ?? [:]).appending(contentsOf: _defaultHeaders)
         
-        return _executor.perform(method: method, url: url, parameters: parameters, headers: newHeaders, encoding: encoding)
+        return _executor.perform(method: method, url: url, parameters: parameters, headers: newHeaders, encodeAs: encodeAs)
             .flatMapError { [unowned self] in
                 self.mapError(error: $0)
             }
@@ -179,4 +199,13 @@ private extension Dictionary {
         }
     }
     
+}
+
+/**
+    Extension to make an encodable dictionary out of an array
+ */
+private extension Array {
+    func asParameters() -> [String: Any] {
+        return [AbstractRepository.ArrayEncodingParametersKey: self]
+    }
 }

--- a/Networking/Repository/AbstractRepository.swift
+++ b/Networking/Repository/AbstractRepository.swift
@@ -48,8 +48,7 @@ extension AbstractRepository: RepositoryType {
     }
     
     public func performRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
-                                  headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none,
-                                  decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
+                                  headers: [String: String]? = .none, decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
         return performRequest(method: method, path: path, parameters: parameters.asParameters(), headers: headers, encodeAs: ArrayEncoding(), decoder: decoder)
     }
     
@@ -60,8 +59,7 @@ extension AbstractRepository: RepositoryType {
     }
     
     public func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
-                                         headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none,
-                                         decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
+                                         headers: [String: String]? = .none, decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError> {
         return performPollingRequest(method: method, path: path, parameters: parameters.asParameters(), headers: headers, encodeAs: ArrayEncoding(), decoder: decoder)
     }
     
@@ -71,7 +69,7 @@ extension AbstractRepository: RepositoryType {
     }
     
     public func performRequest(method: NetworkingMethod, path: String, parameters: [Any],
-                               headers: [String: String]? = .none, encodeAs: ParameterEncoding? = .none) -> SignalProducer<RawDataResponse, RepositoryError> {
+                               headers: [String: String]? = .none) -> SignalProducer<RawDataResponse, RepositoryError> {
         return performRequest(method: method, path: path, parameters: parameters.asParameters(), headers: headers, encodeAs: ArrayEncoding())
     }
     

--- a/Networking/Repository/RepositoryType.swift
+++ b/Networking/Repository/RepositoryType.swift
@@ -51,8 +51,7 @@ public protocol RepositoryType {
     
     // Same but taking an Array instead of a Dictionary
     func performRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
-                           headers: [String: String]?, encodeAs: ParameterEncoding?,
-                           decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
+                           headers: [String: String]?, decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
     
     /**
      Performs a request and returns a Signal producer.
@@ -77,8 +76,7 @@ public protocol RepositoryType {
     
     // Same but taking an Array instead of a Dictionary
     func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
-                                  headers: [String: String]?, encodeAs: ParameterEncoding?,
-                                  decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
+                                  headers: [String: String]?, decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
     
     /**
      Performs a request and returns a Signal producer.
@@ -99,7 +97,6 @@ public protocol RepositoryType {
                         headers: [String: String]?, encodeAs: ParameterEncoding?) -> SignalProducer<RawDataResponse, RepositoryError>
     
     // Same but taking an Array instead of a Dictionary
-    func performRequest(method: NetworkingMethod, path: String, parameters: [Any],
-                        headers: [String: String]?, encodeAs: ParameterEncoding?) -> SignalProducer<RawDataResponse, RepositoryError>
+    func performRequest(method: NetworkingMethod, path: String, parameters: [Any], headers: [String: String]?) -> SignalProducer<RawDataResponse, RepositoryError>
     
 }

--- a/Networking/Repository/RepositoryType.swift
+++ b/Networking/Repository/RepositoryType.swift
@@ -45,7 +45,13 @@ public protocol RepositoryType {
      A SignalProducer where its value is the decoded entity and its
      error a RepositoryError.
      */
-    func performRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]?, headers: [String: String]?,
+    func performRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]?,
+                           headers: [String: String]?, encodeAs: ParameterEncoding?,
+                           decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
+    
+    // Same but taking an Array instead of a Dictionary
+    func performRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
+                           headers: [String: String]?, encodeAs: ParameterEncoding?,
                            decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
     
     /**
@@ -65,7 +71,13 @@ public protocol RepositoryType {
      A SignalProducer where its value is the decoded entity and its
      error a RepositoryError.
      */
-    func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]?, headers: [String: String]?,
+    func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [String: Any]?,
+                                  headers: [String: String]?, encodeAs: ParameterEncoding?,
+                                  decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
+    
+    // Same but taking an Array instead of a Dictionary
+    func performPollingRequest<T>(method: NetworkingMethod, path: String, parameters: [Any],
+                                  headers: [String: String]?, encodeAs: ParameterEncoding?,
                                   decoder: @escaping Decoder<T>) -> SignalProducer<T, RepositoryError>
     
     /**
@@ -84,6 +96,10 @@ public protocol RepositoryType {
      (URLRequest, HTTPURLResponse, Data) and its error a RepositoryError.
      */
     func performRequest(method: NetworkingMethod, path: String, parameters: [String: Any]?,
-                        headers: [String: String]?) -> SignalProducer<RawDataResponse, RepositoryError>
+                        headers: [String: String]?, encodeAs: ParameterEncoding?) -> SignalProducer<RawDataResponse, RepositoryError>
+    
+    // Same but taking an Array instead of a Dictionary
+    func performRequest(method: NetworkingMethod, path: String, parameters: [Any],
+                        headers: [String: String]?, encodeAs: ParameterEncoding?) -> SignalProducer<RawDataResponse, RepositoryError>
     
 }

--- a/NetworkingTests/Repositories/EntityRepository.swift
+++ b/NetworkingTests/Repositories/EntityRepository.swift
@@ -26,6 +26,7 @@ internal protocol EntityRepositoryType {
     func fetchDefaultFailingEntity() -> SignalProducer<Entity, RepositoryError>
     func fetchCustomFailingEntity() -> SignalProducer<Entity, RepositoryError>
     func fetchCustomFailingEntityMishandlingError() -> SignalProducer<Entity, RepositoryError>
+    func fetchEntityWithArrayParameters() -> SignalProducer<Entity, RepositoryError>
     
 }
 
@@ -88,6 +89,13 @@ internal class EntityRepository: AbstractRepository, EntityRepositoryType {
         return performRequest(method: .get, path: "not-found") {
             decode($0).toResult()
         }.mapCustomError(errors: [399: EntityRepositoryError.madeUpError])
+    }
+    
+    func fetchEntityWithArrayParameters() -> SignalProducer<Entity, RepositoryError> {
+        let parameters: [Any] = ["someParam", 1, "other", 25]
+        return performRequest(method: .get, path: "entity", parameters: parameters) {
+            decode($0).toResult()
+        }
     }
     
 }

--- a/NetworkingTests/Repositories/LocalRequestExecutor.swift
+++ b/NetworkingTests/Repositories/LocalRequestExecutor.swift
@@ -7,6 +7,7 @@
 //
 
 import ReactiveSwift
+import Alamofire
 @testable import Networking
 
 internal class LocalRequestExecutor: RequestExecutorType {
@@ -15,7 +16,7 @@ internal class LocalRequestExecutor: RequestExecutorType {
                  url: URL,
                  parameters: [String: Any]? = .none,
                  headers: [String: String]? = .none,
-                 encoding: Encoding? = .none) -> HTTPResponseProducer {
+                 encodeAs: ParameterEncoding? = .none) -> HTTPResponseProducer {
         let path = buildPath(method: method, url: url)
         
         if let filePath = jsonPathForFile(name: path) {

--- a/NetworkingTests/Tests/EntityRepositorySpec.swift
+++ b/NetworkingTests/Tests/EntityRepositorySpec.swift
@@ -35,7 +35,8 @@ internal class EntityRepositorySpec: QuickSpec {
         }
         
         describe("#fetchEntity") {
-                
+            
+            context("When not using parameters") {
                 it("fetches a single entity from JSON file") { waitUntil { done in
                     repository.fetchEntity().startWithResult {
                         switch $0 {
@@ -44,6 +45,18 @@ internal class EntityRepositorySpec: QuickSpec {
                         }
                     }
                 }}
+            }
+            
+            context("When using an array as parameters") {
+                it("fetches a single entity from JSON file") { waitUntil { done in
+                    repository.fetchEntityWithArrayParameters().startWithResult {
+                        switch $0 {
+                        case .success: done()
+                        case .failure: fail()
+                        }
+                    }
+                }}
+            }
             
         }
         


### PR DESCRIPTION

Changed configurable Encoding for configurable ParameterEncoding. that's more correct and easy to use per request

Added a way to encode Arrays so we dont need to always send parameters as dictionaries